### PR TITLE
entity_metadata_no_hook_node_access() should respect that the $node parameter can be a string or an object

### DIFF
--- a/garmentbox/drupal-org.make
+++ b/garmentbox/drupal-org.make
@@ -37,6 +37,7 @@ projects[diff][version] = "3.2"
 
 projects[entity][subdir] = "contrib"
 projects[entity][version] = "1.x-dev"
+projects[entity][patch][] = "http://drupal.org/files/entity-node-access-1780646-8.patch"
 
 projects[entityreference][subdir] = "contrib"
 projects[entityreference][version] = "1.0"


### PR DESCRIPTION
#163 - Add patch from [d.o](http://drupal.org/node/1780646)
